### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -100,7 +100,7 @@ or
 
 if you're using Search Guard 5.
 
-Each module lives in its own github repository. You can either download the repository and build the jar files yourself via a simple ```mvn install``` command. Or you can choose to download the jar file(s) directly from Maven.
+Each module lives in its own github repository. You can either download the repository and build the jar files yourself via a simple ```mvn install``` command. Or you can choose to download the jar file(s) (choose jar file(s) with dependencies) directly from Maven.
 
 #### REST management API:
 [https://github.com/floragunncom/search-guard-rest-api](https://github.com/floragunncom/search-guard-rest-api)


### PR DESCRIPTION
I'm not sure if this is always the case, but in my case, I mistakenly downloaded only jar files and LDAP auth wasn't working. After, by mistake, looking at the files in test bundle, I noticed there are jars with dependencies in plugin dir. I redownloaded the jars and LDAP auth started to work.