### PR TITLE
Documentation fix

### DIFF
--- a/monitoring.md
+++ b/monitoring.md
@@ -26,6 +26,7 @@ For the `http` monitoring type, add a user with all permissions to carry out the
 sg_monitor:
   cluster:
     - "cluster:admin/xpack/monitoring/*"
+    - "cluster:admin/ingest/pipeline/get"
     - "indices:admin/template/get"
     - "indices:admin/template/put"
     - "indices:admin/*get"

--- a/monitoring.md
+++ b/monitoring.md
@@ -14,7 +14,6 @@ In `elasticsearch.yml`, disable all componentes but monitoring:
 xpack.monitoring.enabled: true
 xpack.graph.enabled: false
 xpack.ml.enabled: false
-xpack.reporting.enabled: false
 xpack.security.enabled: false
 xpack.watcher.enabled: false
 ```
@@ -33,7 +32,7 @@ sg_monitor:
     - CLUSTER_MONITOR
     - CLUSTER_COMPOSITE_OPS
   indices:
-    '.monitoring*':
+    '?monitoring*':
       '*':
         - INDICES_ALL
 ```
@@ -91,7 +90,6 @@ xpack.graph.enabled: false
 xpack.ml.enabled: false
 xpack.reporting.enabled: false
 xpack.security.enabled: false
-xpack.watcher.enabled: false
 ```
 
 ## Known issues and limitations


### PR DESCRIPTION
Some XPack modules can only be disabled in elasticsearch.yml or kibana.yml (more info on [Elastic page](https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling)).

In my case, monitor user also needed `cluster:admin/ingest/pipeline/get` permissions. 