### PR TITLE
add a line regarding the first run of sgadmin.sh

### DIFF
--- a/configuration_roles_mapping.md
+++ b/configuration_roles_mapping.md
@@ -11,6 +11,10 @@ Depending on your configuration, you can use the following data to assign a requ
 * Common name
   * the DN of the client certificate sent with the request.
 
+Backend roles are not the same as searchguard roles. 
+
+Backend roles are roles that Search Guard retrieves from an authorization backend like LDAP, which is configured in the authz section of the sg_config file. These roles are then mapped to the roles Search Guard uses to define which permissions a given user or host possesses. The permissions themselves can be defined in sg_action_groups, and the searchguard (not backend) roles are defined in sg_roles, while sg_roles_mapping defined the connection between particular users and specific roles. If you have not defined or enabled an authorization backend in sg_config, and thus have no additional backend roles being fetched, there will be nothing to enter in the backendroles entry of the mapping file.
+
 Backend users, roles and hosts are mapped to Search Guard roles in the file `sg_roles_mapping.yml`.
 
 Syntax:

--- a/sgadmin.md
+++ b/sgadmin.md
@@ -250,4 +250,6 @@ The following switched control the Search Guard index settings.
 | -era | Enable replica auto-expand.|
 | -dra | Disable replica auto-expand.|
 
+The first time you run sgadmin.sh, the ```-us```, ```-era```, ```dra```, and ```-rl``` (reload configuration), flags can cause the initial setup to fail, as the searchguard index does not yet exist.
+
 See chapter [index management](sgindex.md) for more details on how the Search Guard index is structured and how to manage it.


### PR DESCRIPTION
the -rl flag appears to cause an initial run of sgadmin.sh to fail against new clusters as it expects a non-existent searchguard index. The linked issue discussion mentions the effect regarding the three flags mentioned in this document, however, the sgadmin tool's java code suggests that -rl also may have this effect but it is not reflected in the issue discussion nor the documentation. 

https://github.com/floragunncom/search-guard/issues/228

https://github.com/floragunncom/search-guard/blob/master/src/main/java/com/floragunn/searchguard/tools/SearchGuardAdmin.java#L113 

also, the difference between backend and mapping roles was not clear in the doc

https://groups.google.com/forum/#!topic/search-guard/IycDaR8dtCY