### PR TITLE
Fixed mentions of REQUIRED related to searchguard.ssl.http.clientauth_mode

### DIFF
--- a/clientcert_auth.md
+++ b/clientcert_auth.md
@@ -12,7 +12,7 @@ Search Guard already ships with client certificate based authentication.  No add
 
 ## Configuration
 
-In order for Search Guard to pick up client certificate on the REST layer, you need to set the `clientauth_mode` in `elasticsearch.yml` to either `OPTIONAL` or `REQUIRED`:
+In order for Search Guard to pick up client certificate on the REST layer, you need to set the `clientauth_mode` in `elasticsearch.yml` to either `OPTIONAL` or `REQUIRE`:
 
 ```
 searchguard.ssl.http.clientauth_mode: OPTIONAL

--- a/managementapi.md
+++ b/managementapi.md
@@ -30,7 +30,7 @@ After that, restart all nodes to activate the module.
 
 The Search Guard index can only be accessed with an admin certificate. This is the same certificate that you use when executing [sgadmin](sgadmin.md).
 
-In order for Search Guard to pick up this certificate on the REST layer, you need to set the `clientauth_mode` in `elasticsearch.yml` to either `OPTIONAL` or `REQUIRED`:
+In order for Search Guard to pick up this certificate on the REST layer, you need to set the `clientauth_mode` in `elasticsearch.yml` to either `OPTIONAL` or `REQUIRE`:
 
 ```
 searchguard.ssl.http.clientauth_mode: OPTIONAL


### PR DESCRIPTION
[Tests](https://github.com/floragunncom/search-guard/blob/868180aba1e2c01ea29642cf9948ffdd607bb051/src/test/java/com/floragunn/searchguard/SGTests.java#L269) are great. 

tls_configuration.md got it right