### PR TITLE
Fixed quotation marks

### DIFF
--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -133,7 +133,7 @@ elasticsearch.password: "kibanaserver"
 elasticsearch.ssl.verificationMode: none
 
 # Whitelist the Search Guard Multi Tenancy Header
-elasticsearch.requestHeadersWhitelist: [ “Authorization”, “sgtenant” ]
+elasticsearch.requestHeadersWhitelist: [ "Authorization", "sgtenant" ]
 ```
 
 ## Start Kibana


### PR DESCRIPTION
In order to avoid copy & paste confusions when installing the plugin.