### PR TITLE
Rename endpoint to get all role mappings

### DIFF
--- a/_docs/restapi_api_rolesmapping.md
+++ b/_docs/restapi_api_rolesmapping.md
@@ -50,7 +50,7 @@ GET /_searchguard/api/rolesmapping/sg_role_starfleet
 ### Get all role mappings
 
 ```
-GET /_searchguard/api/rolesmapping/{rolename}
+GET /_searchguard/api/rolesmapping
 ```
 
 Returns all role mappings in JSON format.


### PR DESCRIPTION
The endpoint for retrieving a single role mapping and all role mappings is the same, which
is a minor error. This PR fixes the documentation.

```
Get a single role mapping

GET /_searchguard/api/rolesmapping/{rolename}

Get all role mappings

GET /_searchguard/api/rolesmapping/{rolename}
```
