### PR TITLE
Elasticsearch .url config option was deprecated

### DIFF
--- a/_docs/kibana_authentication_basicauth.md
+++ b/_docs/kibana_authentication_basicauth.md
@@ -79,7 +79,7 @@ searchguard.auth.type: "basicauth"
 searchguard.cookie.password: &lt;encryption key, min. 32 characters&gt;
 
 # Use HTTPS instead of HTTP
-elasticsearch.url: "https://&lt;hostname&gt;.com:&lt;http port&gt;"
+elasticsearch.hosts: ["https://&lt;hostname&gt;.com:&lt;http port&gt;"]
 
 # Configure the Kibana internal server user
 elasticsearch.username: "kibanaserver"

--- a/_docs/kibana_authentication_jwt.md
+++ b/_docs/kibana_authentication_jwt.md
@@ -81,7 +81,7 @@ searchguard.jwt.header: 'Authorization'
 searchguard.jwt.url_param: 'jwtparam'
 
 # Use HTTPS instead of HTTP
-elasticsearch.url: "https://&lt;hostname&gt;.com:&lt;http port&gt;"
+elasticsearch.hosts: ["https://&lt;hostname&gt;.com:&lt;http port&gt;"]
 
 # Configure the Kibana internal server user
 elasticsearch.username: "kibanaserver"

--- a/_docs/kibana_authentication_proxy.md
+++ b/_docs/kibana_authentication_proxy.md
@@ -55,7 +55,7 @@ searchguard.basicauth.enabled: false
 searchguard.auth.type: "proxy"
 
 # Use HTTPS instead of HTTP
-elasticsearch.url: "https://&lt;hostname&gt;.com:&lt;http port&gt;"
+elasticsearch.hosts: ["https://&lt;hostname&gt;.com:&lt;http port&gt;"]
 
 # Configure the Kibana internal server user
 elasticsearch.username: "kibanaserver"

--- a/_docs/kibana_authentication_types.md
+++ b/_docs/kibana_authentication_types.md
@@ -36,13 +36,13 @@ This is the default. If the user tries to access Kibana and has no active sessio
 
 In this mode, the user is authenticated by a third party system, like an identity provider that issues JSON web tokens, a Kerberos realm or an authenticating proxy. The Kibana plugin will forward any HTTP headers containing user crendentials to Search Guard. As with Basic Authentication, Search Guard uses these credentials for assigning roles and permissions.
 
-*Hint: You cannot the Basic Authentication login page and SSO authentication together.*
+*Hint: You cannot have the Basic Authentication login page and SSO authentication together.*
 
 ### Whitelisting HTTP headers
 
 By default, Kibana does not pass any HTTP header other than `Authorization` to Elasticsearch. If you try to transmit any other header, it is silently discarded.
 
-In order for SSO to work, make sure that any HTTP header that is required for yur configured authentication type is added to the `elasticsearch.requestHeadersWhitelist` configuration entry in `kibana.yml`. 
+In order for SSO to work, make sure that any HTTP header that is required for your configured authentication type is added to the `elasticsearch.requestHeadersWhitelist` configuration entry in `kibana.yml`.
 
 Example:
 

--- a/_docs/kibana_installation.md
+++ b/_docs/kibana_installation.md
@@ -76,10 +76,10 @@ elasticsearch.password: "kibanaserver"
 
 ## Setting up SSL/TLS
 
-If you use TLS on the Elasticsearch REST layer, you need to configure Kibana accordingly. Set the protocol on the entry `elasticsearch.url` to `https`:
+If you use TLS on the Elasticsearch REST layer, you need to configure Kibana accordingly. Set the protocol on the entry `elasticsearch.hosts` to `https`:
 
 ```yaml
-elasticsearch.url: "https://localhost:9200"
+elasticsearch.hosts: ["https://localhost:9200"]
 ```
 
 All requests that Kibana makes to Elasticsearch will now use HTTPS instead of HTTP.

--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -134,7 +134,7 @@ If you've used the demo configuration to initializing Search Guard as outlined a
 
 ```yaml
 # Use HTTPS instead of HTTP
-elasticsearch.url: "https://localhost:9200"
+elasticsearch.hosts: ["https://localhost:9200"]
 
 # Configure the Kibana internal server user
 elasticsearch.username: "kibanaserver"

--- a/_docs/quickstart_windows.md
+++ b/_docs/quickstart_windows.md
@@ -139,7 +139,7 @@ If you've used the demo configuration to initializing Search Guard as outlined a
 
 ```yaml
 # Use HTTPS instead of HTTP
-elasticsearch.url: "https://localhost:9200"
+elasticsearch.hosts: ["https://localhost:9200"]
 
 # Configure the Kibana internal server user
 elasticsearch.username: "kibanaserver"


### PR DESCRIPTION
Use .hosts instead. Ref: https://github.com/elastic/kibana/pull/21928